### PR TITLE
Split countertop and backsplash cost calculations

### DIFF
--- a/pricing/calculator.py
+++ b/pricing/calculator.py
@@ -34,11 +34,24 @@ def calculate_dvierka(p: LeadIn) -> float:
     unit = (base_price * (1 + dph_rate)) * marza
     return unit * door_area
 
-# 4) Cena pracovnej dosky + backsplash
-def calculate_prac_doska_zastena(p: LeadIn) -> float:
+# 4) Cena pracovnej dosky
+def calculate_prac_doska(p: LeadIn) -> float:
+    if not p.material_pracovnej_dosky or p.material_pracovnej_dosky == "bez":
+        return 0.0
     length = p.length_spod + p.length_spod_vrch
     base_price = PRICES["ceny_pracovna_doska"][p.material_pracovnej_dosky]
-    marza= PRICES["marza"]
+    marza = PRICES["marza"]
+    dph_rate = PRICES["dph"]
+    unit = (base_price * (1 + dph_rate)) * marza
+    return length * unit
+
+# 4b) Cena zásteny
+def calculate_zastena(p: LeadIn) -> float:
+    if not p.material_pracovnej_dosky or p.material_pracovnej_dosky == "bez":
+        return 0.0
+    length = p.length_spod + p.length_spod_vrch
+    base_price = PRICES["ceny_pracovna_doska"][p.material_pracovnej_dosky]
+    marza = PRICES["marza"]
     dph_rate = PRICES["dph"]
     unit = (base_price * (1 + dph_rate)) * marza
     return length * unit
@@ -121,11 +134,11 @@ def calculate_logistika(p: LeadIn) -> Tuple[float, float]:
 def calculate_total(p: LeadIn) -> Tuple[float, dict]:
     c_korpus = calculate_korpus(p)
     c_dv = calculate_dvierka(p)
-    c_pr = calculate_prac_doska_zastena(p)
-    c_zas = calculate_prac_doska_zastena(p) if p.zastena else 0.0
+    c_pr = calculate_prac_doska(p)
+    c_zas = calculate_zastena(p) if p.zastena else 0.0
     c_isl = calculate_island(p)
     c_ex = calculate_extras(p)
-    subtotal = c_korpus + c_dv + c_pr + c_isl + c_ex + (p.extra_price or 0)
+    subtotal = c_korpus + c_dv + c_pr + c_zas + c_isl + c_ex + (p.extra_price or 0)
     c_mont = subtotal * PRICES["montaz_pct"]
     c_dopr, c_vyn = calculate_logistika(p)
     subtotal_after_discount = subtotal * (1 - p.discount_pct) - p.discount_abs

--- a/pricing/config.py
+++ b/pricing/config.py
@@ -1,6 +1,6 @@
 import yaml
 from pathlib import Path
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     google_api_key: str = ""

--- a/pricing/models.py
+++ b/pricing/models.py
@@ -57,5 +57,5 @@ class LeadIn(BaseModel):
 class Lead(SQLModel, table=True):
     __table_args__ = {"extend_existing": True}
     id: Optional[int] = Field(default=None, primary_key=True)
-    data: dict = Field(sa_column=Column(JSONType), nullable=False)
+    data: dict = Field(sa_column=Column(JSONType))
     quoted_price: float = Field(nullable=False)


### PR DESCRIPTION
## Summary
- Separate countertop and backsplash pricing logic into `calculate_prac_doska` and `calculate_zastena`.
- Update `calculate_total` to use new functions and include backsplash cost in subtotals and breakdown.
- Adapt config and models for compatibility with newer Pydantic/SQLModel versions.

## Testing
- `PYTHONPATH=$PWD pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b3b8f4724832495c635a7314e11b6