### PR TITLE
Double island door area

### DIFF
--- a/pricing/calculator.py
+++ b/pricing/calculator.py
@@ -53,7 +53,7 @@ def calculate_island(p: LeadIn) -> float:
 
     base_dv = PRICES["ceny_dvierka"][p.material_dvierok]
     unit_dv = (base_dv * (1 + PRICES["dph"])) * PRICES["marza"]
-    c_dv = unit_dv * area_k    # Dve strany ostrova
+    c_dv = unit_dv * area_k * 2  # Dve strany ostrova
 
     base_w = PRICES["ceny_pracovna_doska"][p.material_pracovnej_dosky]
     unit_w = (base_w * (1 + PRICES["dph"])) * PRICES["marza"]


### PR DESCRIPTION
## Summary
- Ensure island door pricing covers both faces by doubling the door area multiplier

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pricing')*
- `PYTHONPATH=. pytest -q` *(fails: RuntimeError: Passing nullable is not supported when also passing a sa_column)*

------
https://chatgpt.com/codex/tasks/task_e_689b3c49347083248416c738904c7a56