### PR TITLE
Normalize discount percentage and test 10% savings

### DIFF
--- a/app.py
+++ b/app.py
@@ -103,7 +103,10 @@ with st.sidebar:
                             if data[field_name] is None and isinstance(fields_defaults[field_name], str):
                                 st.session_state[field_name] = ""
                             else:
-                                st.session_state[field_name] = data[field_name]
+                                if field_name == "discount_pct" and data[field_name] is not None:
+                                    st.session_state[field_name] = data[field_name] * 100
+                                else:
+                                    st.session_state[field_name] = data[field_name]
                     else:
                         st.session_state[field_name] = fields_defaults[field_name]
                 st.session_state["lead_id"] = selected_lead.id
@@ -128,7 +131,10 @@ with st.sidebar:
         }:
             temp_data[field_name] = val if val != "" else None
         else:
-            temp_data[field_name] = val
+            if field_name == "discount_pct":
+                temp_data[field_name] = val / 100
+            else:
+                temp_data[field_name] = val
 
     try:
         temp_lead = LeadIn(**temp_data)
@@ -388,7 +394,10 @@ with col1:
                 }:
                     lead_kwargs[field_name] = val if val != "" else None
                 else:
-                    lead_kwargs[field_name] = val
+                    if field_name == "discount_pct":
+                        lead_kwargs[field_name] = val / 100
+                    else:
+                        lead_kwargs[field_name] = val
 
             if st.session_state["lead_id"]:
                 lead_kwargs["id"] = st.session_state["lead_id"]

--- a/pricing/calculator.py
+++ b/pricing/calculator.py
@@ -141,7 +141,7 @@ def calculate_total(p: LeadIn) -> Tuple[float, dict]:
     subtotal = c_korpus + c_dv + c_pr + c_zas + c_isl + c_ex + (p.extra_price or 0)
     c_mont = subtotal * PRICES["montaz_pct"]
     c_dopr, c_vyn = calculate_logistika(p)
-    pct = p.discount_pct / 100
+    pct = p.discount_pct  # already a fraction (e.g., 0.10 for 10%)
     subtotal_after_discount = subtotal * (1 - pct) - p.discount_abs
     total_without_dph = math.ceil((subtotal_after_discount + c_mont + c_dopr + c_vyn) / 20) * 20
     total_with_dph = math.ceil(total_without_dph * (1 + PRICES["dph"]) / 20) * 20

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -86,12 +86,12 @@ def test_discount_percentage_applied():
         sortier=False,
         hidden_coffee=False,
         zastena=False,
-        discount_pct=10.0,
+        discount_pct=0.10,
         discount_abs=0.0,
     )
     total, breakdown = calculate_total(p)
     subtotal = breakdown["subtotal"]
-    pct = p.discount_pct / 100
+    pct = p.discount_pct
     subtotal_after_discount = subtotal * (1 - pct) - p.discount_abs
     expected_without_dph = math.ceil((subtotal_after_discount + breakdown["montaz"] + breakdown["doprava"] + breakdown["vynaska"]) / 20) * 20
     expected_with_dph = math.ceil(expected_without_dph * (1 + PRICES["dph"]) / 20) * 20


### PR DESCRIPTION
## Summary
- Normalize `discount_pct` to a fraction before creating `LeadIn` and when previewing or loading leads
- Compute discounts using fractional percentages in `calculate_total`
- Add unit test to verify applying a 10% discount

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b44e29d78832482092eaa86a65e3d