### PR TITLE
chore: adjust kitchen margins

### DIFF
--- a/config/prices.yaml
+++ b/config/prices.yaml
@@ -22,8 +22,8 @@ ceny_pracovna_doska:
 
 # Koeficienty a prirážky
 dph: 0.23           # 23%
-marza_korpus: 2.5      # násobiteľ na korpus
-marza_dvierka: 3      # násobiteľ na dvierka
+marza_korpus: 2      # násobiteľ na korpus
+marza_dvierka: 2.5      # násobiteľ na dvierka
 marza_pracovka: 2      # násobiteľ na pracovnú dosku
 marza_kovanie: 2        # násobiteľ na kovania
 

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -107,5 +107,5 @@ def test_total_price_known_example():
         material_pracovnej_dosky="bez",
     )
     total, _ = calculate_total(p)
-    assert total == 380
+    assert total == 320
 


### PR DESCRIPTION
## Summary
- update default margin multipliers for cabinets and doors
- fix unit tests to expect new total price

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5837fd0048324896399e3efab0b8b