### PR TITLE
Adjust korpus pricing to new rate

### DIFF
--- a/config/prices.yaml
+++ b/config/prices.yaml
@@ -7,7 +7,7 @@ vyska_full: 2.5
 vyska_island: 0.9
 
 # Základné ceny €/m2 alebo €/m
-cena_korpus_per_m2: 72
+cena_korpus_per_m2: 60
 ceny_dvierka:
   laminát: 36
   folia: 54

--- a/tests/test_calculator.py
+++ b/tests/test_calculator.py
@@ -107,5 +107,5 @@ def test_total_price_known_example():
         material_pracovnej_dosky="bez",
     )
     total, _ = calculate_total(p)
-    assert total == 320
+    assert total == 280
 


### PR DESCRIPTION
## Summary
- lower base korpus price to 60 €/m²
- update pricing test expectation for new korpus rate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b586aca5588324a8bf732922c65d3d